### PR TITLE
rdma-core 58.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libnl-feedstock/pr1/e35bf37

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libnl-feedstock/pr1/e35bf37

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-
-c_stdlib_version:   # [linux]
-  - "2.17"          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,15 +76,9 @@ test:
     - test -f ${PREFIX}/lib/libibnetdisc.so.5.1.58.0
     # 3. Major vendor drivers
     - test -f ${PREFIX}/lib/libhns.so.1.0.58.0
-    - test -f ${PREFIX}/lib/libibmad.so.5.5.58.0
-    - test -f ${PREFIX}/lib/libibnetdisc.so.5.1.58.0
-    - test -f ${PREFIX}/lib/libibumad.so.3.4.58.0
-    - test -f ${PREFIX}/lib/libibverbs
-    - test -f ${PREFIX}/lib/libibverbs.so.1.14.58.0
     - test -f ${PREFIX}/lib/libmana.so.1.0.58.0
     - test -f ${PREFIX}/lib/libmlx4.so.1.0.58.0
     - test -f ${PREFIX}/lib/libmlx5.so.1.25.58.0
-    - test -f ${PREFIX}/lib/librdmacm.so.1.3.58.0
     - test -f ${PREFIX}/lib/libibverbs/libbnxt_re-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libcxgb4-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/liberdma-rdmav57.so
@@ -96,7 +90,6 @@ test:
     - test -f ${PREFIX}/lib/libibverbs/libqedr-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libsiw-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libvmw_pvrdma-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so
     # 4. Cloud vendor drivers
     - test -f ${PREFIX}/lib/libefa.so.1.3.58.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     # 1. Diagnostic tools
     - test -x ${PREFIX}/bin/ib_acme
     - test -x ${PREFIX}/bin/ibv_devices
-    - ${PREFIX}/bin/ibv_devices -V
+    # ${PREFIX}/bin/ibv_devices -v -> return an empty list of device+node GUID and finished command with 1. False positive.
     - test -x ${PREFIX}/bin/ibv_devinfo
     - test -x ${PREFIX}/bin/ibv_asyncwatch
     # 2. Benchmarking tools
@@ -82,13 +82,11 @@ test:
     - test -f ${PREFIX}/lib/libibumad.so*
     - test -f ${PREFIX}/lib/libibmad.so*
     - test -f ${PREFIX}/lib/libibnetdisc.so*
-    # 3. Plugin directory structure
-    - test -d ${PREFIX}/lib/libibverbs
-    # 4. Major vendor drivers
+    # 3. Major vendor drivers
     - test -f ${PREFIX}/lib/libibverbs/libmlx4-rdmav*.so
     - test -f ${PREFIX}/lib/libibverbs/libmlx5-rdmav*.so
     - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so
-    # 5. Cloud vendor drivers  
+    # 4. Cloud vendor drivers
     - test -f ${PREFIX}/lib/libibverbs/libefa-rdmav*.so
 
     # +++++ HEADERS +++++

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,7 +85,6 @@ test:
     - test -f ${PREFIX}/lib/libmlx4.so.1.0.58.0
     - test -f ${PREFIX}/lib/libmlx5.so.1.25.58.0
     - test -f ${PREFIX}/lib/librdmacm.so.1.3.58.0
-    - test -f ${PREFIX}/lib/libibverbs/libmlx4-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libbnxt_re-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libcxgb4-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/liberdma-rdmav57.so
@@ -97,7 +96,6 @@ test:
     - test -f ${PREFIX}/lib/libibverbs/libqedr-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libsiw-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libvmw_pvrdma-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libmlx5-rdmav*.so
     - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so
     # 4. Cloud vendor drivers
     - test -f ${PREFIX}/lib/libefa.so.1.3.58.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,14 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/linux-rdma/rdma-core/archive/v{{ version }}.tar.gz
+  url: https://github.com/linux-{{ name.split('-')[0] }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 08a554e0f95bb6869f9fbc2b1eb5521a85104dda9bf730db42b1a10d0b009e28
   patches:
     - 0001-Remove-assertions-on-longer-than-sockaddr_un.sun_pat.patch
 
 build:
   number: 0
-  skip: true  # [not linux]
+  skip: True  # [not linux]
   run_exports:
     - {{ pin_subpackage("rdma-core", max_pin=None) }}
 
@@ -29,22 +29,71 @@ requirements:
     - python
     - docutils
   host:
-    - libnl
-    - libsystemd
-    - libudev
+    - libnl 3.11
+    # https://github.com/linux-rdma/rdma-core/blob/master/CMakeLists.txt#L843-L848
+    # - libsystemd
+    # - libudev
 
 test:
   commands:
-    - test -f "${PREFIX}/bin/ibv_devices"
-    # Test `ibv_devices` when building natively
-    - ${PREFIX}/bin/ibv_devices            # [build_platform == target_platform]
+    # +++++ Binaries +++++
+    # 1. Diagnostic tools
+    - ${PREFIX}/bin/ib_acme --help
+    # 2. Benchmarking tools
+    - ${PREFIX}/bin/ibv_rc_pingpong --help || ${PREFIX}/bin/ibv_rc_pingpong -h
+    - ${PREFIX}/bin/ibv_ud_pingpong --help || ${PREFIX}/bin/ibv_ud_pingpong -h
+    - ${PREFIX}/bin/ibv_uc_pingpong --help || ${PREFIX}/bin/ibv_uc_pingpong -h
+    - ${PREFIX}/bin/ibv_srq_pingpong --help || ${PREFIX}/bin/ibv_srq_pingpong -h
+    - ${PREFIX}/bin/ibv_xsrq_pingpong --help || ${PREFIX}/bin/ibv_xsrq_pingpong -h
+    # 3. RDMA CM tools
+    - ${PREFIX}/bin/rdma_client --help || ${PREFIX}/bin/rdma_client -h
+    - ${PREFIX}/bin/rdma_server --help || ${PREFIX}/bin/rdma_server -h
+    - ${PREFIX}/bin/rdma_xclient --help || ${PREFIX}/bin/rdma_xclient -h
+    - ${PREFIX}/bin/rdma_xserver --help || ${PREFIX}/bin/rdma_xserver -h
+    - ${PREFIX}/bin/mckey --help || ${PREFIX}/bin/mckey -h
+    - ${PREFIX}/bin/ucmatose --help || ${PREFIX}/bin/ucmatose -h
+    - ${PREFIX}/bin/udaddy --help || ${PREFIX}/bin/udaddy -h
+    - ${PREFIX}/bin/rping --help || ${PREFIX}/bin/rping -h
+    # 4. Stream/copy tools
+    - ${PREFIX}/bin/rstream --help || ${PREFIX}/bin/rstream -h
+    - ${PREFIX}/bin/riostream --help || ${PREFIX}/bin/riostream -h
+    - ${PREFIX}/bin/rcopy --help || ${PREFIX}/bin/rcopy -h
+    # 5. Utilities
+    - ${PREFIX}/bin/ibv_asyncwatch --help || ${PREFIX}/bin/ibv_asyncwatch -h
+    - ${PREFIX}/bin/cmtime --help || ${PREFIX}/bin/cmtime -h
+    - ${PREFIX}/bin/udpong --help || ${PREFIX}/bin/udpong -h
+    # 6. Binary existence verification
+    - test -x ${PREFIX}/bin/ibv_devices
+    # +++++ LIBRARIES +++++
+    # 1. Core RDMA libraries
+    - test -f ${PREFIX}/lib/libibverbs.so*       # [linux]
+    - test -f ${PREFIX}/lib/librdmacm.so*        # [linux]
+    # symbolic links
+    - test -L ${PREFIX}/lib/libibverbs.so        # [linux]
+    - test -L ${PREFIX}/lib/librdmacm.so         # [linux]
+    # pkgconfig files
+    - test -f ${PREFIX}/lib/pkgconfig/libibverbs.pc
+    - test -f ${PREFIX}/lib/pkgconfig/librdmacm.pc
+    # 2. Essential management libraries
+    - test -f ${PREFIX}/lib/libibumad.so*        # [linux]
+    - test -f ${PREFIX}/lib/libibmad.so*         # [linux]
+    - test -f ${PREFIX}/lib/libibnetdisc.so*     # [linux]
+    # 3. Major vendor drivers
+    - test -f ${PREFIX}/lib/libibverbs/libmlx4-rdmav*.so    # [linux]
+    - test -f ${PREFIX}/lib/libibverbs/libmlx5-rdmav*.so    # [linux]
+    - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so     # [linux]
+    # 4. Cloud vendor drivers
+    - test -f ${PREFIX}/lib/libibverbs/libefa-rdmav*.so     # [linux]
 
 about:
   home: https://github.com/linux-rdma/rdma-core
+  summary: RDMA Core Userspace Libraries and Daemons
   license: Linux-OpenIB
   license_family: BSD
   license_file: LICENSE.txt
-  summary: RDMA Core Userspace Libraries and Daemons
+  description: |
+    RDMA Core Userspace Libraries and Daemons
+    This is the userspace components for the Linux Kernel's drivers/infiniband subsystem.
   doc_url: https://github.com/linux-rdma/rdma-core
   dev_url: https://github.com/linux-rdma/rdma-core
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,54 +36,62 @@ requirements:
 
 test:
   commands:
-    # +++++ Binaries +++++
+    # +++++ BINARIES +++++
     # 1. Diagnostic tools
-    - ${PREFIX}/bin/ib_acme --help
-    # 2. Benchmarking tools
-    - ${PREFIX}/bin/ibv_rc_pingpong --help || ${PREFIX}/bin/ibv_rc_pingpong -h
-    - ${PREFIX}/bin/ibv_ud_pingpong --help || ${PREFIX}/bin/ibv_ud_pingpong -h
-    - ${PREFIX}/bin/ibv_uc_pingpong --help || ${PREFIX}/bin/ibv_uc_pingpong -h
-    - ${PREFIX}/bin/ibv_srq_pingpong --help || ${PREFIX}/bin/ibv_srq_pingpong -h
-    - ${PREFIX}/bin/ibv_xsrq_pingpong --help || ${PREFIX}/bin/ibv_xsrq_pingpong -h
-    # 3. RDMA CM tools
-    - ${PREFIX}/bin/rdma_client --help || ${PREFIX}/bin/rdma_client -h
-    - ${PREFIX}/bin/rdma_server --help || ${PREFIX}/bin/rdma_server -h
-    - ${PREFIX}/bin/rdma_xclient --help || ${PREFIX}/bin/rdma_xclient -h
-    - ${PREFIX}/bin/rdma_xserver --help || ${PREFIX}/bin/rdma_xserver -h
-    - ${PREFIX}/bin/mckey --help || ${PREFIX}/bin/mckey -h
-    - ${PREFIX}/bin/ucmatose --help || ${PREFIX}/bin/ucmatose -h
-    - ${PREFIX}/bin/udaddy --help || ${PREFIX}/bin/udaddy -h
-    - ${PREFIX}/bin/rping --help || ${PREFIX}/bin/rping -h
-    # 4. Stream/copy tools
-    - ${PREFIX}/bin/rstream --help || ${PREFIX}/bin/rstream -h
-    - ${PREFIX}/bin/riostream --help || ${PREFIX}/bin/riostream -h
-    - ${PREFIX}/bin/rcopy --help || ${PREFIX}/bin/rcopy -h
-    # 5. Utilities
-    - ${PREFIX}/bin/ibv_asyncwatch --help || ${PREFIX}/bin/ibv_asyncwatch -h
-    - ${PREFIX}/bin/cmtime --help || ${PREFIX}/bin/cmtime -h
-    - ${PREFIX}/bin/udpong --help || ${PREFIX}/bin/udpong -h
-    # 6. Binary existence verification
+    - test -x ${PREFIX}/bin/ib_acme
     - test -x ${PREFIX}/bin/ibv_devices
+    - test -x ${PREFIX}/bin/ibv_devinfo
+    - test -x ${PREFIX}/bin/ibv_asyncwatch
+    - test -x ${PREFIX}/bin/ucx_info
+    # 2. Benchmarking tools
+    - test -x ${PREFIX}/bin/ibv_rc_pingpong
+    - test -x ${PREFIX}/bin/ibv_ud_pingpong
+    - test -x ${PREFIX}/bin/ibv_uc_pingpong
+    - test -x ${PREFIX}/bin/ibv_srq_pingpong
+    - test -x ${PREFIX}/bin/ibv_xsrq_pingpong
+    # 3. RDMA CM tools
+    - test -x ${PREFIX}/bin/rdma_client
+    - test -x ${PREFIX}/bin/rdma_server
+    - test -x ${PREFIX}/bin/rdma_xclient
+    - test -x ${PREFIX}/bin/rdma_xserver
+    - test -x ${PREFIX}/bin/mckey
+    - test -x ${PREFIX}/bin/ucmatose
+    - test -x ${PREFIX}/bin/udaddy
+    - test -x ${PREFIX}/bin/rping
+    # 4. Stream/copy tools
+    - test -x ${PREFIX}/bin/rstream
+    - test -x ${PREFIX}/bin/riostream
+    - test -x ${PREFIX}/bin/rcopy
+    # 5. Utilities
+    - test -x ${PREFIX}/bin/cmtime
+    - test -x ${PREFIX}/bin/udpong
+
     # +++++ LIBRARIES +++++
     # 1. Core RDMA libraries
-    - test -f ${PREFIX}/lib/libibverbs.so*       # [linux]
-    - test -f ${PREFIX}/lib/librdmacm.so*        # [linux]
-    # symbolic links
-    - test -L ${PREFIX}/lib/libibverbs.so        # [linux]
-    - test -L ${PREFIX}/lib/librdmacm.so         # [linux]
+    - test -f ${PREFIX}/lib/libibverbs.so*
+    - test -f ${PREFIX}/lib/librdmacm.so*
+    # Symbolic links
+    - test -L ${PREFIX}/lib/libibverbs.so
+    - test -L ${PREFIX}/lib/librdmacm.so
     # pkgconfig files
     - test -f ${PREFIX}/lib/pkgconfig/libibverbs.pc
     - test -f ${PREFIX}/lib/pkgconfig/librdmacm.pc
     # 2. Essential management libraries
-    - test -f ${PREFIX}/lib/libibumad.so*        # [linux]
-    - test -f ${PREFIX}/lib/libibmad.so*         # [linux]
-    - test -f ${PREFIX}/lib/libibnetdisc.so*     # [linux]
-    # 3. Major vendor drivers
-    - test -f ${PREFIX}/lib/libibverbs/libmlx4-rdmav*.so    # [linux]
-    - test -f ${PREFIX}/lib/libibverbs/libmlx5-rdmav*.so    # [linux]
-    - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so     # [linux]
-    # 4. Cloud vendor drivers
-    - test -f ${PREFIX}/lib/libibverbs/libefa-rdmav*.so     # [linux]
+    - test -f ${PREFIX}/lib/libibumad.so*
+    - test -f ${PREFIX}/lib/libibmad.so*
+    - test -f ${PREFIX}/lib/libibnetdisc.so*
+    # 3. Plugin directory structure
+    - test -d ${PREFIX}/lib/libibverbs
+    # 4. Major vendor drivers
+    - test -f ${PREFIX}/lib/libibverbs/libmlx4-rdmav*.so
+    - test -f ${PREFIX}/lib/libibverbs/libmlx5-rdmav*.so
+    - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so
+    # 5. Cloud vendor drivers  
+    - test -f ${PREFIX}/lib/libibverbs/libefa-rdmav*.so
+    
+    # +++++ HEADERS +++++
+    - test -f ${PREFIX}/include/infiniband/verbs.h
+    - test -f ${PREFIX}/include/rdma/rdma_cma.h
 
 about:
   home: https://github.com/linux-rdma/rdma-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
 build:
   number: 0
   skip: True  # [not linux]
+  ignore_run_exports:
+    - libstdcxx-ng
   run_exports:
     - {{ pin_subpackage("rdma-core", max_pin=None) }}
 
@@ -40,9 +42,9 @@ test:
     # 1. Diagnostic tools
     - test -x ${PREFIX}/bin/ib_acme
     - test -x ${PREFIX}/bin/ibv_devices
+    - ${PREFIX}/bin/ibv_devices -V
     - test -x ${PREFIX}/bin/ibv_devinfo
     - test -x ${PREFIX}/bin/ibv_asyncwatch
-    - test -x ${PREFIX}/bin/ucx_info
     # 2. Benchmarking tools
     - test -x ${PREFIX}/bin/ibv_rc_pingpong
     - test -x ${PREFIX}/bin/ibv_ud_pingpong
@@ -88,7 +90,7 @@ test:
     - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so
     # 5. Cloud vendor drivers  
     - test -f ${PREFIX}/lib/libibverbs/libefa-rdmav*.so
-    
+
     # +++++ HEADERS +++++
     - test -f ${PREFIX}/include/infiniband/verbs.h
     - test -f ${PREFIX}/include/rdma/rdma_cma.h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,6 @@ source:
 build:
   number: 0
   skip: True  # [not linux]
-  ignore_run_exports:
-    - libstdcxx-ng
   run_exports:
     - {{ pin_subpackage("rdma-core", max_pin=None) }}
 
@@ -70,28 +68,39 @@ test:
 
     # +++++ LIBRARIES +++++
     # 1. Core RDMA libraries
-    - test -f ${PREFIX}/lib/libibverbs.so*
-    - test -f ${PREFIX}/lib/librdmacm.so*
-    # Symbolic links
-    - test -L ${PREFIX}/lib/libibverbs.so
-    - test -L ${PREFIX}/lib/librdmacm.so
-    # pkgconfig files
-    - test -f ${PREFIX}/lib/pkgconfig/libibverbs.pc
-    - test -f ${PREFIX}/lib/pkgconfig/librdmacm.pc
+    - test -f ${PREFIX}/lib/libibverbs.so.1.14.58.0
+    - test -f ${PREFIX}/lib/librdmacm.so.1.3.58.0
     # 2. Essential management libraries
-    - test -f ${PREFIX}/lib/libibumad.so*
-    - test -f ${PREFIX}/lib/libibmad.so*
-    - test -f ${PREFIX}/lib/libibnetdisc.so*
+    - test -f ${PREFIX}/lib/libibumad.so.3.4.58.0
+    - test -f ${PREFIX}/lib/libibmad.so.5.5.58.0
+    - test -f ${PREFIX}/lib/libibnetdisc.so.5.1.58.0
     # 3. Major vendor drivers
-    - test -f ${PREFIX}/lib/libibverbs/libmlx4-rdmav*.so
+    - test -f ${PREFIX}/lib/libhns.so.1.0.58.0
+    - test -f ${PREFIX}/lib/libibmad.so.5.5.58.0
+    - test -f ${PREFIX}/lib/libibnetdisc.so.5.1.58.0
+    - test -f ${PREFIX}/lib/libibumad.so.3.4.58.0
+    - test -f ${PREFIX}/lib/libibverbs
+    - test -f ${PREFIX}/lib/libibverbs.so.1.14.58.0
+    - test -f ${PREFIX}/lib/libmana.so.1.0.58.0
+    - test -f ${PREFIX}/lib/libmlx4.so.1.0.58.0
+    - test -f ${PREFIX}/lib/libmlx5.so.1.25.58.0
+    - test -f ${PREFIX}/lib/librdmacm.so.1.3.58.0
+    - test -f ${PREFIX}/lib/libibverbs/libmlx4-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libbnxt_re-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libcxgb4-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/liberdma-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libhfi1verbs-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libipathverbs-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libirdma-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libmthca-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libocrdma-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libqedr-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libsiw-rdmav57.so
+    - test -f ${PREFIX}/lib/libibverbs/libvmw_pvrdma-rdmav57.so
     - test -f ${PREFIX}/lib/libibverbs/libmlx5-rdmav*.so
     - test -f ${PREFIX}/lib/libibverbs/librxe-rdmav*.so
     # 4. Cloud vendor drivers
-    - test -f ${PREFIX}/lib/libibverbs/libefa-rdmav*.so
-
-    # +++++ HEADERS +++++
-    - test -f ${PREFIX}/include/infiniband/verbs.h
-    - test -f ${PREFIX}/include/rdma/rdma_cma.h
+    - test -f ${PREFIX}/lib/libefa.so.1.3.58.0
 
 about:
   home: https://github.com/linux-rdma/rdma-core


### PR DESCRIPTION
rdma-core 58.0 

**Destination channel:** Defaults

### Links

- [PKG-9097]
- dev_url:        https://github.com/linux-rdma/rdma-core/tree/v58.0
- conda_forge:    https://github.com/conda-forge/rdma-core-feedstock

### Explanation of changes:

- new version number


[PKG-9097]: https://anaconda.atlassian.net/browse/PKG-9097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ