### PR TITLE
rdma-core v60.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,37 +68,31 @@ test:
 
     # +++++ LIBRARIES +++++
     # 1. Core RDMA libraries
-    - test -f ${PREFIX}/lib/libibverbs.so.1.15.60.0
-    - test -f ${PREFIX}/lib/librdmacm.so.1.4.60.0
+    - test -f ${PREFIX}/lib/libibverbs.so.1
+    - test -f ${PREFIX}/lib/librdmacm.so.1
     # 2. Essential management libraries
-    - test -f ${PREFIX}/lib/libibumad.so.3.4.60.0
-    - test -f ${PREFIX}/lib/libibmad.so.5.5.60.0
-    - test -f ${PREFIX}/lib/libibnetdisc.so.5.1.60.0
+    - test -f ${PREFIX}/lib/libibumad.so.3
+    - test -f ${PREFIX}/lib/libibmad.so.5
+    - test -f ${PREFIX}/lib/libibnetdisc.so.5
     # 3. Major vendor drivers
-    - test -f ${PREFIX}/lib/libhns.so.1.0.60.0
-    - test -f ${PREFIX}/lib/libmana.so.1.0.60.0
-    - test -f ${PREFIX}/lib/libmlx4.so.1.0.60.0
-    - test -f ${PREFIX}/lib/libmlx5.so.1.25.60.0
-    - test -f ${PREFIX}/lib/libibverbs/libbnxt_re-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libcxgb4-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/liberdma-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libhfi1verbs-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libipathverbs-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libirdma-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libmthca-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libocrdma-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libqedr-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libsiw-rdmav59.so
-    - test -f ${PREFIX}/lib/libibverbs/libvmw_pvrdma-rdmav59.so
+    - test -f ${PREFIX}/lib/libhns.so.1
+    - test -f ${PREFIX}/lib/libmana.so.1
+    - test -f ${PREFIX}/lib/libmlx4.so.1
+    - test -f ${PREFIX}/lib/libmlx5.so.1
     # 4. Cloud vendor drivers
-    - test -f ${PREFIX}/lib/libefa.so.1.4.60.0
+    - test -f ${PREFIX}/lib/libefa.so.1
 
 about:
   home: https://github.com/linux-rdma/rdma-core
   summary: RDMA Core Userspace Libraries and Daemons
-  license: Linux-OpenIB
-  license_family: BSD
-  license_file: LICENSE.txt
+  # https://github.com/linux-rdma/rdma-core/blob/v60.0/COPYING.md
+  license: GPL-2.0 OR OpenIB-BSD-MIT
+  license_family: Other
+  license_file:
+      - COPYING.md
+      - COPYING.BSD_FB
+      - COPYING.BSD_MIT
+      - COPYING.GPL2
   description: |
     RDMA Core Userspace Libraries and Daemons
     This is the userspace components for the Linux Kernel's drivers/infiniband subsystem.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,30 +68,30 @@ test:
 
     # +++++ LIBRARIES +++++
     # 1. Core RDMA libraries
-    - test -f ${PREFIX}/lib/libibverbs.so.1.14.58.0
-    - test -f ${PREFIX}/lib/librdmacm.so.1.3.58.0
+    - test -f ${PREFIX}/lib/libibverbs.so.1.15.60.0
+    - test -f ${PREFIX}/lib/librdmacm.so.1.4.60.0
     # 2. Essential management libraries
-    - test -f ${PREFIX}/lib/libibumad.so.3.4.58.0
-    - test -f ${PREFIX}/lib/libibmad.so.5.5.58.0
-    - test -f ${PREFIX}/lib/libibnetdisc.so.5.1.58.0
+    - test -f ${PREFIX}/lib/libibumad.so.3.4.60.0
+    - test -f ${PREFIX}/lib/libibmad.so.5.5.60.0
+    - test -f ${PREFIX}/lib/libibnetdisc.so.5.1.60.0
     # 3. Major vendor drivers
-    - test -f ${PREFIX}/lib/libhns.so.1.0.58.0
-    - test -f ${PREFIX}/lib/libmana.so.1.0.58.0
-    - test -f ${PREFIX}/lib/libmlx4.so.1.0.58.0
-    - test -f ${PREFIX}/lib/libmlx5.so.1.25.58.0
-    - test -f ${PREFIX}/lib/libibverbs/libbnxt_re-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libcxgb4-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/liberdma-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libhfi1verbs-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libipathverbs-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libirdma-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libmthca-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libocrdma-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libqedr-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libsiw-rdmav57.so
-    - test -f ${PREFIX}/lib/libibverbs/libvmw_pvrdma-rdmav57.so
+    - test -f ${PREFIX}/lib/libhns.so.1.0.60.0
+    - test -f ${PREFIX}/lib/libmana.so.1.0.60.0
+    - test -f ${PREFIX}/lib/libmlx4.so.1.0.60.0
+    - test -f ${PREFIX}/lib/libmlx5.so.1.25.60.0
+    - test -f ${PREFIX}/lib/libibverbs/libbnxt_re-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libcxgb4-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/liberdma-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libhfi1verbs-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libipathverbs-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libirdma-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libmthca-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libocrdma-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libqedr-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libsiw-rdmav59.so
+    - test -f ${PREFIX}/lib/libibverbs/libvmw_pvrdma-rdmav59.so
     # 4. Cloud vendor drivers
-    - test -f ${PREFIX}/lib/libefa.so.1.3.58.0
+    - test -f ${PREFIX}/lib/libefa.so.1.4.60.0
 
 about:
   home: https://github.com/linux-rdma/rdma-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rdma-core" %}
-{% set version = "58.0" %}
+{% set version = "60.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/linux-{{ name.split('-')[0] }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 08a554e0f95bb6869f9fbc2b1eb5521a85104dda9bf730db42b1a10d0b009e28
+  sha256: aa9ca1f5a9e356f770441f52254ddc70ff0a4df76a25383e422075eb730efb4b
   patches:
     - 0001-Remove-assertions-on-longer-than-sockaddr_un.sun_pat.patch
 
@@ -23,7 +23,7 @@ requirements:
     - {{ stdlib("c") }}
     - {{ compiler("cxx") }}
     - cmake
-    - ninja
+    - ninja-base
     - pandoc
     - pkg-config
     - python


### PR DESCRIPTION
rdma-core 60.0

**Destination channel:** defaults

### Links

- [PKG-11019](https://anaconda.atlassian.net/browse/PKG-11019) 
- [Upstream repository](https://github.com/linux-rdma/rdma-core)
- [Upstream changelog/diff](https://github.com/linux-rdma/rdma-core/releases/tag/v60.0)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Bump version to v60.0
- Updated tests added by the previous packager

### Notes:

- This feedstock has more tests compared to its conda-forge counterpart.


[PKG-11019]: https://anaconda.atlassian.net/browse/PKG-11019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ