### PR TITLE
rdma-core v61.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rdma-core" %}
-{% set version = "60.0" %}
+{% set version = "61.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/linux-{{ name.split('-')[0] }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: aa9ca1f5a9e356f770441f52254ddc70ff0a4df76a25383e422075eb730efb4b
+  sha256: c7db745c72fca8168503b73bb0c6f0ff110a865944b7f73f791480c2bff1ab87
   patches:
     - 0001-Remove-assertions-on-longer-than-sockaddr_un.sun_pat.patch
 


### PR DESCRIPTION
rdma-core 61.0

**Destination channel:** defaults

### Links

- [PKG-12768](https://anaconda.atlassian.net/browse/PKG-12768) 
- [Upstream repository](https://github.com/linux-rdma/rdma-core/tree/v61.0)
- [Upstream changelog/diff](https://github.com/linux-rdma/rdma-core/releases/tag/v61.0)

### Explanation of changes:

- Upgrade `rdma-core` to v61.0 for CUDA 12.9 release


[PKG-12768]: https://anaconda.atlassian.net/browse/PKG-12768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ